### PR TITLE
Correct Page ID when ADR are in sub-directories (#1)

### DIFF
--- a/mkdocs_material_adr/plugins/graph/plugin.py
+++ b/mkdocs_material_adr/plugins/graph/plugin.py
@@ -156,7 +156,7 @@ class AdrPlugin(BasePlugin[AdrPluginConfig]):
 
 
 def _get_id_from_page(page: Page) -> str:
-    return page.url.replace("/", "")
+    return page.url.split("/")[-2]
 
 
 log = logging.getLogger("mkdocs")


### PR DESCRIPTION
Hi,

I put my ADR into a sub-directory and the plugin was crashing with issues finding the page id for `extends`, etc.
The issue is how the page-id is generated,  it assumes the URL of the page is in the root.  
Otherwise a page at `src/this/is/a/subdir/0001-draft.md`  gets an id `thisisasubdir0001-draft`  which is non obvious and not very nice.
This change breaks the URL on `/` and gets only the last part of the URL as the id so now, no matter the path:
`src/this/is/a/subdir/0001-draft.md` => `0001-draft`