### PR TITLE
docs: warn about material plugin namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ theme:
 
 plugins:
   - mkdocs-material-adr/adr
+  - material/search # Note: all material plugin should be namespaced for them to work
+
 ```
 
 ## Features


### PR DESCRIPTION
fix: #6